### PR TITLE
Add leveled logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.1.9 - (unreleased)
   - Added flag to support ElasticSearch v6.x correctly
+  - Added built-in leveled logging
 
 
 ## v0.1.8 - (2020-03-09)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.1.9 - (unreleased)
   - Added flag to support ElasticSearch v6.x correctly
   - Added built-in leveled logging
+  - Deprecated `:transform` in favor of transducers via `:transduce`
 
 
 ## v0.1.8 - (2020-03-09)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Available publishers:
 Existing logging libraries are based on a design from the 80s and
 early 90s.  Most of the systems at the time where developed in
 standalone servers where logging messages to console or file was the
-predominant thing to do. Logging was mostly providing debbugging
+predominant thing to do. Logging was mostly providing debugging
 information and system behavioural introspection.
 
 Most of modern systems are distributed in virtualized machines that
@@ -72,7 +72,7 @@ decades.
 I believe we need the break free of these anachronistic design and use
 event loggers, *not message loggers*, which are designed for dynamic
 distributed systems living in cloud and using centralized log
-aggregators. *So here is **μ/log** designed for this very purpose.*
+aggregators. *So here is ***μ/log*** designed for this very purpose.*
 
 
 ## Usage
@@ -153,7 +153,7 @@ aggregate on it in a specialized timeseries database.
 Adding events which are rich in attributes and dimensions is extremely
 useful, however it is not easy to have all the attributes and
 dimensions at your disposal everywhere in the code. To get around
-this problem **μ/log** supports the use of context.
+this problem ***μ/log*** supports the use of context.
 
 There are two levels of context, a global level and a local one.
 
@@ -263,7 +263,7 @@ Here some best practices to follow while logging events:
   * Use namespaced keywords or qualified strings for the `event-name`
   * Log values not opaque objects, objects will be turned into strings
     which diminishes their value
-  * Do now log mutable values, since rendering is done asynchronously
+  * Do not log mutable values, since rendering is done asynchronously
     you could be logging a different state. If values are mutable
     capture the current state (deref) and log it.
   * Avoid logging deeply nested maps, they are hard to query.

--- a/README.md
+++ b/README.md
@@ -346,11 +346,15 @@ The available configuration options:
  ;; Will be composed with the transformation described below.
  :level nil
 
+ ;; DEPRECATED since 0.1.9
  ;; a function to apply to the sequence of events before publishing.
  ;; This transformation function can be used to filter, tranform,
  ;; anonymise events before they are published to a external system.
  ;; by defatult there is no transformation.  (since v0.1.8)
  :transform identity
+
+ ;; like `:transform`, but is a transducer.  (since v0.1.9)
+ :transduce (map identity)
  }
 
 ```
@@ -382,11 +386,15 @@ The available configuration options:
  ;; Will be composed with the transformation described below.
  :level nil
 
+ ;; DEPRECATED since 0.1.9
  ;; a function to apply to the sequence of events before publishing.
  ;; This transformation function can be used to filter, tranform,
  ;; anonymise events before they are published to a external system.
  ;; by defatult there is no transformation.  (since v0.1.8)
  :transform identity
+
+ ;; like `:transform`, but is a transducer.  (since v0.1.9)
+ :transduce (map identity)
  }
 
 ```
@@ -461,11 +469,15 @@ The available configuration options:
  ;; Will be composed with the transformation described below.
  :level nil
 
+ ;; DEPRECATED since 0.1.9
  ;; a function to apply to the sequence of events before publishing.
  ;; This transformation function can be used to filter, tranform,
  ;; anonymise events before they are published to a external system.
  ;; by defatult there is no transformation.  (since v0.1.8)
  :transform identity
+
+ ;; like `:transform`, but is a transducer.  (since v0.1.9)
+ :transduce (map identity)
  }
 
 ```
@@ -522,11 +534,15 @@ The available configuration options:
  ;; Will be composed with the transformation described below.
  :level nil
 
+ ;; DEPRECATED since 0.1.9
  ;; a function to apply to the sequence of events before publishing.
  ;; This transformation function can be used to filter, tranform,
  ;; anonymise events before they are published to a external system.
  ;; by defatult there is no transformation.  (since v0.1.8)
  :transform identity
+
+ ;; like `:transform`, but is a transducer.  (since v0.1.9)
+ :transduce (map identity)
  }
 ```
 

--- a/doc/custom-publishers.md
+++ b/doc/custom-publishers.md
@@ -5,14 +5,14 @@ The target system can be anything: from the standard output to a fancy
 timeseries database, a SQL or NOSQL database, a streaming platform,
 a cloud system or even a machine learning system.
 
-**μ/log** tries to make as simple as possible to write a *stateful*
+***μ/log*** tries to make as simple as possible to write a *stateful*
 publisher. Most of the time is fairly easy to write a publisher which
 is stateless and doesn't care about downstream system availability.
 However, we know that real systems and real environments are usually
 more complex, they have to account for short time glitches, speed and
 throughput.
 
-**μ/log** tries to do the heavy lifting of managing the publishing
+***μ/log*** tries to do the heavy lifting of managing the publishing
 buffers in such way that downstream system can have transient failure
 and still send the events once they recover. At the same time, we want
 to avoid that the failure of a downstream system makes our events to
@@ -25,8 +25,8 @@ make place for fresher events.  Should the downstream system recover
 at any point, the publisher will be able to send the full content of
 the buffer.
 
-For more information about how the **μ/log**'s internals work, please
-read [μ/log internals](./doc/mulog-internals.md).
+For more information about how the ***μ/log***'s internals work, please
+read [μ/log internals](./mulog-internals.md).
 
 
 ``` clojure
@@ -52,9 +52,9 @@ read [μ/log internals](./doc/mulog-internals.md).
 
 Let's dissect it function by function.  The first one is
 `agent-buffer`, it returns a Clojure `agent` which is wrapping a
-ring-buffer which is where the events will be delivered.  Depending
-events will be pushed to the downstream system you should size this
-accordingly. For example 10000 events is good size to account for a
+ring-buffer which is where the events will be delivered.  You should
+size this according to how events will be pushed to the downstream
+system. For example 10000 events is good size to account for a
 transient error in the target system without taking too much memory.
 We already have an agent wrapping a ring-buffer so pretty much this
 will always return `(rb/agent-buffer 10000)`.
@@ -66,12 +66,12 @@ frequent the target system will be called.  The larger it is the more
 you have to account for buffering space. Strike a good balance between
 DDOS'ing the target system and buffering too much.
 
-Finally, `publish` is the actual call. **μ/log** will call this
+Finally, `publish` is the actual call. ***μ/log*** will call this
 function at regular intervals (`publish-delay`) and pass the content
 of the buffer.  The function has to push the events to the target
 system and return **the new content of the buffer**.  Calls to this
 function will be serialized (no concurrent calls) so it is important
-to don't take up too much time and set a timeout that is smaller than
+to not take up too much time and set a timeout that is smaller than
 the `publish-delay`.
 
 
@@ -123,7 +123,7 @@ you can start it with:
    :pretty-print true})
 ```
 
-That was simple right? let's add some complications; instead of
+That was simple right? Let's add some complications; instead of
 printing to the console we want to write to a file so that we have to
 keep the file writer at hand (in our state) and we want also to pace
 how many items we print at once.  This might be useful if the target
@@ -189,19 +189,19 @@ at most 1000 items.
 ```
 
 In the above example we can see that we take only a portion of the
-buffer content. Importantly we save the offset of the last item we
+buffer content. Importantly we **save the offset of the last item** we
 publish so that we can discard all the messages in the buffer up and
 including last offset. The rest of the publisher is pretty much the same.
 
 
 ## Error handling
 
-So far we haven't spoke about error handling at all, that it is
+So far we haven't spoke about error handling at all, that's
 because there is not much to say. If the `publish` function raises an
 exception, nothing to worry about, the publish will be retried after
 the `publish-delay` interval passed. So for example, if you are
 posting to a remote system and the system in temporarily unavailable,
-nothing to worry about, **μ/log** it will keep retrying.  Should the
+nothing to worry about, ***μ/log*** will keep retrying.  Should the
 target system not be available for a longer period of time, nothing to
 worry about in this case as well, because the buffer will keep filling
 up until it is full and then start dropping older events ensuring that
@@ -210,7 +210,7 @@ the system won't run out of memory.
 
 ## Support for user-defined transformations
 
-If you are building a general purpose publisher it is good idea to
+If you are building a general purpose publisher it is a good idea to
 provide the ability to take a general transformation which can be
 applied to the events.  This can be very useful for filtering which
 events you which to send to a specific publisher or for performing

--- a/doc/els-name-mangling.md
+++ b/doc/els-name-mangling.md
@@ -193,7 +193,7 @@ Indexed as `orderId.s` won't clash with `orderId.i`.
 The name mangling is enabled by default, but it can be disabled via
 configuration:
 
-``` clojure
+```clojure
 {:type :elasticsearch
 
  ;; ElasticSearch endpoint (REQUIRED)

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -16,9 +16,8 @@ with a transformation which convert the duration into milliseconds.
 ```clojure
 (μ/start-publisher!
  {:type :console
-  :transform (fn [events]
-               (map (fn [{:keys [mulog/duration] :as e}]
-                      (if duration
-                        (update e :mulog/duration quot 1000000)
-                        e)) events))})
+  :transduce (map (fn [{:keys [mulog/duration] :as e}]
+                    (if duration
+                      (update e :mulog/duration quot 1000000)
+                      e)))})
 ```

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -13,7 +13,7 @@ which will be applied to all the events, prior the publishing.
 For example, the following snippet starts the console publisher
 with a transformation which convert the duration into milliseconds.
 
-``` clojure
+```clojure
 (μ/start-publisher!
  {:type :console
   :transform (fn [events]

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -1,8 +1,8 @@
 # F.A.Q.
 
-## Q: How do I **μ/log** to send the `:mulog/duration` in milliseconds?
+## Q: How do I ***μ/log*** to send the `:mulog/duration` in milliseconds?
 
-**μ/log** will send the `:mulog/duration` in nanoseconds because it
+***μ/log*** will send the `:mulog/duration` in nanoseconds because it
 uses the monotonic timer with a nanoseconds precision which guarantee
 the highest precision even on very small measurement.
 

--- a/doc/mulog-internals.md
+++ b/doc/mulog-internals.md
@@ -1,10 +1,10 @@
 # μ/log internals
 
-This article illustrates how **μ/log** works internally.  The
+This article illustrates how ***μ/log*** works internally.  The
 objective of this article is to deepen the understanding of the
 technical choices and their consequences.
 
-The design goals of **μ/log** are the following:
+The design goals of ***μ/log*** are the following:
 
   1. log events in their pure form (values).
   2. negligible impact on performances, it should be super-fast.
@@ -23,9 +23,9 @@ Looking at the above picture let's see what happens step by step.
 ### Step (1) - Logging
 
 Logging starts with a call to the `log` function. At this point
-**μ/log** does the least amount of work possible. In fact, it only
+***μ/log*** does the least amount of work possible. In fact, it only
 appends the event and the context captured at that point to a
-`ring-buffer`. **μ/log** uses a *ring-buffer* to ensure that the use
+`ring-buffer`. ***μ/log*** uses a *ring-buffer* to ensure that the use
 of the memory is bound and it will not grow indiscriminately
 potentially breaking the rule `n.3` and causing the application to run
 out of memory. The operation is cheap (typically less than **200
@@ -57,12 +57,12 @@ At regular intervals, the `publish` function of the `PPublisher`
 protocol is called with the content of the buffer.  The publishing
 function can take the all the events (or part of them) and send them
 to the downstream system.  If the operation is successful, the
-publisher function return the new state of the buffer minus the events
+publisher function returns the new state of the buffer minus the events
 which have been successfully sent.  In case of failure, the operation
 will be re-attempted at the next round.
 
 Any sort of formatting, transformation and manipulation of the events
-it is done at this time, right before sending to the target system.
+is done at this time, right before sending to the target system.
 Therefore, it is important that all the values passed to the `log` function
 are immutable.
 Each system might require different pre-processing, and this processing

--- a/examples/roads-disruptions/README.md
+++ b/examples/roads-disruptions/README.md
@@ -50,15 +50,18 @@ curl -si http://localhost:8000/healthcheck
 
 # to retrieve the current list of disruptions around London
 curl -si http://localhost:8000/disruptions
+
+# to log a few events on purpose
+curl -si http://localhost:8000/{verbose,debug,info,warning,error,fatal}
 ```
 Every interaction is logged in ***μ/log***.
 
 The logs will be sent to the following destinations:
 
-  - Console standard output
-  - Filesystem: `/tmp/mulog/events.log`
-  - Kafka topic: `mulog`
-  - ElasticSearch index `mulog-YYYY.MM.DD`
+  - Console standard output (verbose and above)
+  - Filesystem: `/tmp/mulog/events.log` (debug and above)
+  - Kafka topic: `mulog` (info and above)
+  - ElasticSearch index `mulog-YYYY.MM.DD` (info and above)
 
 To see the events sent to Kafka run:
 
@@ -68,7 +71,7 @@ docker exec -ti roads-disruptions_broker_1 /usr/bin/kafka-console-consumer --boo
 
 Here a sample of the events that will be sent:
 
-``` clojure
+```clojure
 ;; This event is sent at the application start
 {:mulog/event-name :disruptions/app-started,
  :mulog/timestamp 1582624436517,

--- a/examples/roads-disruptions/src/com/brunobonacci/disruptions/api.clj
+++ b/examples/roads-disruptions/src/com/brunobonacci/disruptions/api.clj
@@ -75,6 +75,36 @@
    (wrap-json-response
     (routes
 
+     (GET "/verbose" []
+          (μ/verbose ::request)
+          {:status 200
+           :body {:status "OK" :message "verbose."}})
+
+     (GET "/debug" []
+          (μ/debug ::request)
+          {:status 200
+           :body {:status "OK" :message "debug."}})
+
+     (GET "/info" []
+          (μ/info ::request)
+          {:status 200
+           :body {:status "OK" :message "info."}})
+
+     (GET "/warning" []
+          (μ/warning ::request)
+          {:status 200
+           :body {:status "OK" :message "warning."}})
+
+     (GET "/error" []
+          (μ/error ::request)
+          {:status 200
+           :body {:status "OK" :message "error."}})
+
+     (GET "/fatal" []
+          (μ/fatal ::request)
+          {:status 200
+           :body {:status "OK" :message "fatal."}})
+
      (GET "/healthcheck" []
           {:status 200
            :body {:status "OK" :message "All good."}})

--- a/examples/roads-disruptions/src/com/brunobonacci/disruptions/main.clj
+++ b/examples/roads-disruptions/src/com/brunobonacci/disruptions/main.clj
@@ -1,5 +1,6 @@
 (ns com.brunobonacci.disruptions.main
   (:require [com.brunobonacci.mulog :as μ]
+            [com.brunobonacci.mulog.levels :as lvl]
             [com.brunobonacci.disruptions.api :as api]
             [cemerick.url :refer [url url-encode]]
             [ring.adapter.jetty :as http])
@@ -22,13 +23,20 @@
    {:type :multi
     :publishers
     [ ;; send events to the stdout
-     {:type :console}
+     {:type :console
+      :level ::lvl/verbose}
      ;; send events to a file
-     {:type :simple-file :filename "/tmp/mulog/events.log"}
+     {:type :simple-file
+      :level ::lvl/debug
+      :filename "/tmp/mulog/events.log"}
      ;; send events to ELS
-     {:type :elasticsearch :url  "http://localhost:9200/"}
+     {:type :elasticsearch
+      :level ::lvl/info
+      :url  "http://localhost:9200/"}
      ;; send events to kafka
-     {:type :kafka :kafka {:bootstrap.servers "192.168.200.200:9092,127.0.0.1:9092"}}]}})
+     {:type :kafka
+      :level ::lvl/info
+      :kafka {:bootstrap.servers "192.168.200.200:9092,127.0.0.1:9092"}}]}})
 
 
 
@@ -37,7 +45,10 @@
 
   ;; set global context
   (μ/set-global-context!
-   {:app-name "roads-disruptions", :version "0.1.0", :env "local"})
+   {:mulog/level ::lvl/info
+    :app-name "roads-disruptions"
+    :version "0.1.0"
+    :env "local"})
 
   (μ/start-publisher! mulog))
 

--- a/mulog-core/README.md
+++ b/mulog-core/README.md
@@ -1,6 +1,6 @@
 # μ/log
 
-Core implementation of **μ/log** library.
+Core implementation of ***μ/log*** library.
 
 ## Usage
 

--- a/mulog-core/dev/user.clj
+++ b/mulog-core/dev/user.clj
@@ -3,6 +3,7 @@
             [clojure.java.io :as io]
             [clojure.string :as str]
             [com.brunobonacci.mulog.buffer :as rb]
+            [com.brunobonacci.mulog.levels :as lvl]
             [com.brunobonacci.mulog.utils :as ut]
             [com.brunobonacci.mulog.flakes :refer [flake]]))
 
@@ -14,6 +15,32 @@
   (def p1 (u/start-publisher! {:type :console}))
 
   (u/log ::hello :to "World!" :v 2)
+
+  (p1)
+
+  (def p1 (u/start-publisher! {:type :console
+                               :level ::lvl/info}))
+
+  (u/log ::hello :to "World!")
+
+  (u/verbose ::hello :to "World!")
+  (u/debug   ::hello :to "World!")
+  (u/info    ::hello :to "World!")
+  (u/warning ::hello :to "World!")
+  (u/error   ::hello :to "World!")
+  (u/fatal   ::hello :to "World!")
+
+  (u/set-global-context! {:app "demo" :version 1 :env "local"
+                          :mulog/level ::lvl/warning})
+
+  (u/log ::hello :to "World!")
+
+  (u/verbose ::hello :to "World!")
+  (u/debug   ::hello :to "World!")
+  (u/info    ::hello :to "World!")
+  (u/warning ::hello :to "World!")
+  (u/error   ::hello :to "World!")
+  (u/fatal   ::hello :to "World!")
 
   (def p2 (u/start-publisher! {:type :simple-file :filename "/tmp/mulog.edn"}))
 
@@ -67,7 +94,45 @@
                            (filter #(< (:v %) 500))
                            (map #(update % :v -))))}))
 
+  (u/log ::hello :to "World!" :v 1000)
+  (u/log ::hello :to "World!" :v 200)
+
   (x)
+
+  (def xform1
+    (u/start-publisher!
+      {:type :console
+       :transform (fn [events]
+                    (->> events
+                         (filter #(< (:v %) 500))
+                         (map #(update % :v -))
+                         (map #(update % :mulog/level (comp str/upper-case
+                                                            name)))))}))
+
+  (u/info ::hello :to "World!" :v 1000)
+  (u/info ::hello :to "World!" :v 200)
+
+  (xform1)
+
+  (def h (-> (make-hierarchy)
+             (derive ::wockety ::wack)
+             (derive ::pockety ::wockety)
+             (derive ::hockety ::pockety)))
+
+  (def xform2 (u/start-publisher!
+                {:type :console
+                 :transform (fn [events]
+                              (->> events
+                                   ((lvl/->filter ::pockety h :log-level))
+                                   (map #(update % :v inc))))}))
+
+  (u/log ::hello :to "World!" :v 1)
+  (u/log ::hello :to "World!" :log-level ::wack    :v 1)
+  (u/log ::hello :to "World!" :log-level ::wockety :v 2)
+  (u/log ::hello :to "World!" :log-level ::pockety :v 3)
+  (u/log ::hello :to "World!" :log-level ::hockety :v 4)
+
+  (xform2)
 
   )
 

--- a/mulog-core/dev/user.clj
+++ b/mulog-core/dev/user.clj
@@ -102,12 +102,10 @@
   (def xform1
     (u/start-publisher!
       {:type :console
-       :transform (fn [events]
-                    (->> events
-                         (filter #(< (:v %) 500))
-                         (map #(update % :v -))
-                         (map #(update % :mulog/level (comp str/upper-case
-                                                            name)))))}))
+       :transduce (comp (filter #(< (:v %) 500))
+                        (map #(update % :v -))
+                        (map #(update % :mulog/level (comp str/upper-case
+                                                           name))))}))
 
   (u/info ::hello :to "World!" :v 1000)
   (u/info ::hello :to "World!" :v 200)
@@ -121,10 +119,8 @@
 
   (def xform2 (u/start-publisher!
                 {:type :console
-                 :transform (fn [events]
-                              (->> events
-                                   ((lvl/->filter ::pockety h :log-level))
-                                   (map #(update % :v inc))))}))
+                 :transduce (comp (lvl/->filter ::pockety h :log-level)
+                                  (map #(update % :v inc)))}))
 
   (u/log ::hello :to "World!" :v 1)
   (u/log ::hello :to "World!" :log-level ::wack    :v 1)

--- a/mulog-core/src/com/brunobonacci/mulog.clj
+++ b/mulog-core/src/com/brunobonacci/mulog.clj
@@ -37,7 +37,8 @@ For more information, please visit: https://github.com/BrunoBonacci/mulog
 "}
     com.brunobonacci.mulog
   (:require [com.brunobonacci.mulog.core :as core]
-            [com.brunobonacci.mulog.buffer :as rb]))
+            [com.brunobonacci.mulog.buffer :as rb]
+            [com.brunobonacci.mulog.levels :as lvl]))
 
 
 
@@ -47,7 +48,7 @@ For more information, please visit: https://github.com/BrunoBonacci/mulog
        :dynamic true}
   *default-logger*
   ;; The choice of an atom against an agent it is mainly based on
-  ;; bechmarks. Items can be added to the buffer with a mean time of
+  ;; benchmarks. Items can be added to the buffer with a mean time of
   ;; 285 nanos, against the 1.2μ of the agent. The agent might be
   ;; better in cases in which the atom is heavily contended and many
   ;; retries are required in that case the agent could be better,
@@ -109,7 +110,7 @@ For more information, please visit: https://github.com/BrunoBonacci/mulog
   library to log important events, but rather than logging words, add
   data points. To log a new event this is the format:
 
-  ``` clojure
+  ```clojure
   (μ/log event-name, key1 value1, key2 value2, ... keyN valueN)
   ```
 
@@ -122,7 +123,7 @@ For more information, please visit: https://github.com/BrunoBonacci/mulog
   For example should you want to log the event of a your login, you
   could add:
 
-  ``` clojure
+  ```clojure
   (μ/log ::user-logged :user-id \"1234567\" :remote-ip \"1.2.3.4\"
      :auth-method :password-login)
   ```
@@ -150,7 +151,7 @@ For more information, please visit: https://github.com/BrunoBonacci/mulog
   The `start-publisher!` function returns a zero-argument function
   which can be used to stop the publisher.
 
-  ``` clojure
+  ```clojure
   (def stop (μ/start-publisher! {:type :console}))
   (μ/log ::hi)
   ;; prints something like:
@@ -167,14 +168,14 @@ For more information, please visit: https://github.com/BrunoBonacci/mulog
   Another built-in publisher is the `:simple-file` publisher which
   just outputs events to a file in EDN format.
 
-  ``` clojure
+  ```clojure
   (μ/start-publisher! {:type :simple-file :filename \"/tmp/mulog/events.log\"})
   ```
 
   You can also have multiple publishers defined in one place using the `:multi`
   publisher configuration:
 
-  ``` clojure
+  ```clojure
   (μ/start-publisher!
    {:type :multi
     :publishers
@@ -253,7 +254,7 @@ For more information, please visit: https://github.com/BrunoBonacci/mulog
   *global context*, all the properties of the *local context* and all
   *inline properties*.
 
-  ``` clojure
+  ```clojure
   (μ/with-context {:order \"abc123\"}
     (μ/log ::item-processed :item-id \"sku-123\" :qt 2))
 
@@ -275,6 +276,26 @@ For more information, please visit: https://github.com/BrunoBonacci/mulog
   [context & body]
   `(binding [*local-context* (merge *local-context* ~context)]
      ~@body))
+
+
+(defmacro verbose [event-name & pairs]
+  `(with-context {:mulog/level ::lvl/verbose}
+     (log ~event-name ~@pairs)))
+(defmacro debug [event-name & pairs]
+  `(with-context {:mulog/level ::lvl/debug}
+     (log ~event-name ~@pairs)))
+(defmacro info [event-name & pairs]
+  `(with-context {:mulog/level ::lvl/info}
+     (log ~event-name ~@pairs)))
+(defmacro warning [event-name & pairs]
+  `(with-context {:mulog/level ::lvl/warning}
+     (log ~event-name ~@pairs)))
+(defmacro error [event-name & pairs]
+  `(with-context {:mulog/level ::lvl/error}
+     (log ~event-name ~@pairs)))
+(defmacro fatal [event-name & pairs]
+  `(with-context {:mulog/level ::lvl/fatal}
+     (log ~event-name ~@pairs)))
 
 
 

--- a/mulog-core/src/com/brunobonacci/mulog.clj
+++ b/mulog-core/src/com/brunobonacci/mulog.clj
@@ -3,9 +3,9 @@
       "
 Logging library designed to log data events instead of plain words.
 
-This namespace provides the core functions of **μ/log**.
+This namespace provides the core functions of ***μ/log***.
 
-The purpose of **μ/log** is provide the ability to generate events
+The purpose of ***μ/log*** is provide the ability to generate events
 directly from your code. The instrumentation process is very simple
 and similar to add a traditional log line, but instead of logging
 a message which hardly anyone will ever read, your can log an
@@ -13,7 +13,7 @@ event, a data point, with all the attributes and properties which
 make sense for that particular event and let the machine use it
 in a later time.
 
-**μ/log** provides the functions to instrument your code with minimal
+***μ/log*** provides the functions to instrument your code with minimal
 impact to performances (few nanoseconds), to buffer events and manage
 the overflow, the dispatching of the stored events to downstream
 systems where they can be processed, indexed, organized and queried to
@@ -23,12 +23,12 @@ system.
 Once you start using event-based metrics you will not want to use
 traditional metrics any more.
 
-Additionally, **μ/log** offer the possibility to trace execution with
+Additionally, ***μ/log*** offer the possibility to trace execution with
 a micro-tracing function called **μ/trace**.  It provides in app
 distributed tracing capabilities with the same simplicity.
 
 The publisher sub-system makes extremely easy to write new publishers
-for new downstream system. **μ/log** manages the hard parts like: the
+for new downstream system. ***μ/log*** manages the hard parts like: the
 buffering, the retries, the memory buffers and the publisher's state.
 It is often required only a dozen lines of code to write a new powerful
 custom publisher and use it in your system.
@@ -186,7 +186,7 @@ For more information, please visit: https://github.com/BrunoBonacci/mulog
   which it will start all the defined publishers all at once.
 
   For more information about available publishers and their configuration
-  as well as how to write your own pulishers please check
+  as well as how to write your own publishers please check
   https://github.com/BrunoBonacci/mulog#publishers
 
   "
@@ -208,7 +208,7 @@ For more information, please visit: https://github.com/BrunoBonacci/mulog
   "Adding events which are rich in attributes and dimensions is
   extremely useful, however it is not easy to have all the attributes
   and dimensions at your disposal everywhere in the code. To get
-  around this problem **μ/log** supports the use of context.
+  around this problem ***μ/log*** supports the use of context.
 
   There are two levels of context, a global level and a local one.
 
@@ -269,7 +269,7 @@ For more information, please visit: https://github.com/BrunoBonacci/mulog
   ```
 
   The local context can be nested and ti will be inherited by
-  all the **μ/log** calls within nested functions as long as they
+  all the ***μ/log*** calls within nested functions as long as they
   are in the same execution thread and which the scope of the block.
   "
   [context & body]

--- a/mulog-core/src/com/brunobonacci/mulog/levels.clj
+++ b/mulog-core/src/com/brunobonacci/mulog/levels.clj
@@ -1,0 +1,41 @@
+(ns ^{:doc
+      "
+Logging library designed to log data events instead of plain words.
+
+This namespace contains a hierarchy for built-in leveled logging
+as well as a helper to build an event filter.
+"}
+    com.brunobonacci.mulog.levels)
+
+(defonce ^{:doc
+           "Leveled logging hierarchy used by the built-in
+            publishers via the `:level` configuration.
+
+            Users can leverage this hierarchy in custom
+            publishers, or build their own version as they
+            see fit.
+
+            `->filter` is a helper to help implementing custom
+            leveled logging mechanisms.
+            "}
+  default-levels (-> (make-hierarchy)
+                     (derive ::debug    ::verbose)
+                     (derive ::info     ::debug)
+                     (derive ::warning  ::info)
+                     (derive ::error    ::warning)
+                     (derive ::fatal    ::error)))
+
+(defn ->filter
+  "takes a logging level, a `hierarchy` (or `default-levels`)
+  and an event key `k` (or `:mulog/level`) and returns a
+  transformation function which filters events on the given key
+  in the hierarchy"
+  ([level]
+   (or (some-> level (->filter default-levels :mulog/level))
+       identity))
+  ([level hierarchy k]
+   (fn [events]
+     (filter (fn [{e-level k}]
+               (isa? hierarchy e-level level))
+             events))))
+

--- a/mulog-core/src/com/brunobonacci/mulog/levels.clj
+++ b/mulog-core/src/com/brunobonacci/mulog/levels.clj
@@ -3,7 +3,7 @@
 Logging library designed to log data events instead of plain words.
 
 This namespace contains a hierarchy for built-in leveled logging
-as well as a helper to build an event filter.
+as well as a helper to build an event filter (transducer).
 "}
     com.brunobonacci.mulog.levels)
 
@@ -16,7 +16,7 @@ as well as a helper to build an event filter.
             see fit.
 
             `->filter` is a helper to help implementing custom
-            leveled logging mechanisms.
+            leveled logging mechanisms using transducers.
             "}
   default-levels (-> (make-hierarchy)
                      (derive ::debug    ::verbose)
@@ -28,14 +28,11 @@ as well as a helper to build an event filter.
 (defn ->filter
   "takes a logging level, a `hierarchy` (or `default-levels`)
   and an event key `k` (or `:mulog/level`) and returns a
-  transformation function which filters events on the given key
-  in the hierarchy"
+  transducer which filters events on the given key in the hierarchy"
   ([level]
    (or (some-> level (->filter default-levels :mulog/level))
-       identity))
+       (map identity)))
   ([level hierarchy k]
-   (fn [events]
-     (filter (fn [{e-level k}]
-               (isa? hierarchy e-level level))
-             events))))
+   (filter (fn [{e-level k}]
+             (isa? hierarchy e-level level)))))
 

--- a/mulog-core/test/com/brunobonacci/mulog/levels_test.clj
+++ b/mulog-core/test/com/brunobonacci/mulog/levels_test.clj
@@ -1,0 +1,30 @@
+(ns com.brunobonacci.mulog.levels-test
+  (:require [com.brunobonacci.mulog.levels :as lvl]
+            [midje.sweet :refer :all]))
+
+(fact
+  "->filter does what it says"
+
+  ((lvl/->filter nil)           [{:id 1 :mulog/level ::lvl/info}])
+  => [{:id 1 :mulog/level ::lvl/info}]
+
+  ((lvl/->filter ::lvl/warning) [{:id 1 :mulog/level ::lvl/info}])
+  => ()
+
+  ((lvl/->filter ::lvl/info)    [{:id 1 :mulog/level ::lvl/info}])
+  => [{:id 1 :mulog/level ::lvl/info}]
+
+  ((lvl/->filter ::lvl/debug)   [{:id 1 :mulog/level ::lvl/info}])
+  => [{:id 1 :mulog/level ::lvl/info}]
+
+  (let [ad-hoc (-> (make-hierarchy)
+                   (derive ::bar ::foo)
+                   (derive ::baz ::bar))]
+    ((lvl/->filter ::bar ad-hoc :some)
+              [{:id 1 :some ::foo}
+               {:id 2 :some ::bar}
+               {:id 3 :some ::bar}
+               ])) => [{:id 2 :some ::bar}
+                       {:id 3 :some ::bar}
+                       ]
+  )

--- a/mulog-core/test/com/brunobonacci/mulog/levels_test.clj
+++ b/mulog-core/test/com/brunobonacci/mulog/levels_test.clj
@@ -5,22 +5,22 @@
 (fact
   "->filter does what it says"
 
-  ((lvl/->filter nil)           [{:id 1 :mulog/level ::lvl/info}])
+  (sequence (lvl/->filter nil)           [{:id 1 :mulog/level ::lvl/info}])
   => [{:id 1 :mulog/level ::lvl/info}]
 
-  ((lvl/->filter ::lvl/warning) [{:id 1 :mulog/level ::lvl/info}])
+  (sequence (lvl/->filter ::lvl/warning) [{:id 1 :mulog/level ::lvl/info}])
   => ()
 
-  ((lvl/->filter ::lvl/info)    [{:id 1 :mulog/level ::lvl/info}])
+  (sequence (lvl/->filter ::lvl/info)    [{:id 1 :mulog/level ::lvl/info}])
   => [{:id 1 :mulog/level ::lvl/info}]
 
-  ((lvl/->filter ::lvl/debug)   [{:id 1 :mulog/level ::lvl/info}])
+  (sequence (lvl/->filter ::lvl/debug)   [{:id 1 :mulog/level ::lvl/info}])
   => [{:id 1 :mulog/level ::lvl/info}]
 
   (let [ad-hoc (-> (make-hierarchy)
                    (derive ::bar ::foo)
                    (derive ::baz ::bar))]
-    ((lvl/->filter ::bar ad-hoc :some)
+    (sequence (lvl/->filter ::bar ad-hoc :some)
               [{:id 1 :some ::foo}
                {:id 2 :some ::bar}
                {:id 3 :some ::bar}

--- a/mulog-core/test/com/brunobonacci/mulog/test_publisher.clj
+++ b/mulog-core/test/com/brunobonacci/mulog/test_publisher.clj
@@ -30,13 +30,13 @@
 
 
 
-(defmacro with-test-pusblisher
+(defmacro with-test-publisher
   [& body]
-  `(with-processing-pusblisher {} ~@body))
+  `(with-processing-publisher {} ~@body))
 
 
 
-(defmacro with-processing-pusblisher
+(defmacro with-processing-publisher
   [config & body]
   `(let [cfg#     (merge {:process identity :rounds 1} ~config)
          inbox#   (atom (rb/ring-buffer 100))

--- a/mulog-core/test/com/brunobonacci/mulog_test.clj
+++ b/mulog-core/test/com/brunobonacci/mulog_test.clj
@@ -8,7 +8,7 @@
 (fact
  "μ/log can log events just with the event name"
 
- (tp/with-test-pusblisher
+ (tp/with-test-publisher
    (u/log :test))
 
  => (just
@@ -23,7 +23,7 @@
 (fact
  "μ/log can log events with additional properties"
 
- (tp/with-test-pusblisher
+ (tp/with-test-publisher
    (u/log :test :value1 1 :v2 "b" :v3 {:d [:e :f :g]}))
 
  => (just
@@ -37,7 +37,7 @@
 (fact
  "μ/log adds attributes from global context if set"
 
- (tp/with-test-pusblisher
+ (tp/with-test-publisher
    (u/set-global-context! {:app "demo" :version 1 :env "local"})
    (u/log :test :v1 1))
 
@@ -52,7 +52,7 @@
 (fact
  "global context can be changed, and changes are reflected"
 
- (tp/with-test-pusblisher
+ (tp/with-test-publisher
    (u/set-global-context! {:app "demo" :version 1 :env "local"})
    (u/log :test :v1 1)
    (u/set-global-context! {:app "demo" :version 2 :env "local"})
@@ -72,7 +72,7 @@
 (fact
  "global context can be update, and changes are reflected"
 
- (tp/with-test-pusblisher
+ (tp/with-test-publisher
    (u/set-global-context! {:app "demo" :version 1 :env "local"})
    (u/log :test :v1 1)
    (u/update-global-context! update :version inc)
@@ -92,7 +92,7 @@
 (fact
  "global context can be overwritten by μ/log"
 
- (tp/with-test-pusblisher
+ (tp/with-test-publisher
    (u/set-global-context! {:app "demo" :version 1 :env "local"})
    (u/log :test :app "new-app"))
 
@@ -107,7 +107,7 @@
 (fact
  "local-context: with-context can be used to add local info"
 
- (tp/with-test-pusblisher
+ (tp/with-test-publisher
    (u/with-context {:local 1}
      (u/log :test)))
 
@@ -121,7 +121,7 @@
 (fact
  "local-context: can be nested"
 
- (tp/with-test-pusblisher
+ (tp/with-test-publisher
    (u/with-context {:local 1}
      (u/with-context {:sub-local :a}
        (u/log :test))))
@@ -136,7 +136,7 @@
 (fact
  "local-context: is only valid within the scope"
 
- (tp/with-test-pusblisher
+ (tp/with-test-publisher
    (u/log :before :l 0)
    (u/with-context {:local 1}
      (u/log :ctx :l 1)
@@ -163,7 +163,7 @@
 (fact
  "local-context: can overwrite parent context"
 
- (tp/with-test-pusblisher
+ (tp/with-test-publisher
    (u/with-context {:local 1}
      (u/with-context {:local 2 :sub-local :a}
        (u/log :test))))
@@ -178,7 +178,7 @@
 (fact
  "local-context: can overwrite global context"
 
- (tp/with-test-pusblisher
+ (tp/with-test-publisher
    (u/set-global-context! {:global 1})
    (u/log :test)
    (u/with-context {:global 2 :local :a}
@@ -196,7 +196,7 @@
 (fact
  "μ/log: can overwrite local & global context"
 
- (tp/with-test-pusblisher
+ (tp/with-test-publisher
    (u/set-global-context! {:global 1})
    (u/log :test :global :overwrite)
    (u/with-context {:global 2 :local :a}
@@ -214,7 +214,7 @@
 (fact
  "μ/log: can overwrite timestamp and namespace"
 
- (tp/with-test-pusblisher
+ (tp/with-test-publisher
    (u/log :test :mulog/timestamp 1 :mulog/namespace "test"))
 
  => [#:mulog{:timestamp 1, :event-name :test, :namespace "test"}]

--- a/mulog-core/test/com/brunobonacci/publisher_test.clj
+++ b/mulog-core/test/com/brunobonacci/publisher_test.clj
@@ -8,7 +8,7 @@
 (fact
  "a successful delivery"
 
- (tp/with-processing-pusblisher
+ (tp/with-processing-publisher
    {}
    (u/log :test))
 
@@ -22,7 +22,7 @@
 (fact
  "the inbox buffer limits the number of events"
 
- (tp/with-processing-pusblisher
+ (tp/with-processing-publisher
    {}
    (dotimes [_ 200]
      (u/log :test)))
@@ -35,7 +35,7 @@
 (fact
  "if the publisher fails it retries"
 
- (tp/with-processing-pusblisher
+ (tp/with-processing-publisher
    {:process (tp/rounds [:fail :ok]) :rounds 2}
    (u/log :test))
 
@@ -49,7 +49,7 @@
 (fact
  "if the publisher fails it retries until it succeeds"
 
- (tp/with-processing-pusblisher
+ (tp/with-processing-publisher
    {:process (tp/rounds [:fail :fail :fail :fail :ok]) :rounds 5}
    (u/log :test))
 

--- a/mulog-core/test/com/brunobonacci/utils_test.clj
+++ b/mulog-core/test/com/brunobonacci/utils_test.clj
@@ -18,3 +18,13 @@
  (ut/remove-nils '(1 nil 3)) => '(1 3)
  (ut/remove-nils #{1 nil 3}) => #{1 3}
  )
+
+
+
+(fact
+ "->transducer does what it says"
+
+ (sequence (ut/->transducer nil) [1 2 3]) => [1 2 3]
+ (sequence (ut/->transducer
+            (fn [coll] (map inc coll))) [1 2 3]) => [2 3 4]
+ )


### PR DESCRIPTION
I've tried to provide a mechanism for leveled logging inside ***μ/log*** which leverages local contexts and transformation functions for filtering.

There are three **standalone** commits:

1. **Fix typos and ***μ/log*** style**
   No code changes, only docs and docstrings.
2. **Add support for leveled logging**
   * Leveraging *local contexts* I've created a bunch of macros related to some usual log levels (`verbose`, `debug`, `info`, `warning`, `error`, `fatal`) stored in a *default* `hierarchy`.
   * Then I've added an *optional* `level` configuration in the built-in (console, simple file, elasticsearh & kafka) publishers, to compose a filter (based on the provided log level configuration) with user-provided custom transformation functions.
   * I've also documented the feature and provided examples for using the log levels as well as how to use the *global context* to setup a default level.
   * And finally I've added a section in "How to write custom publishers" on how to leverage the built-in leveled logging mechanism itself, or the `->filter` helper alone, in order to implement custom leveled logging.
   * All tests pass and the example project logs as expected.
3. **Deprecated `:transform` in favor of transducers via `:transduce`**
   * I've had some fun turning custom transformation functions and log level filter into transducers in order to compose more easily and avoid intermediate collections on arbitrary user logic.
   * The transformation functions are still supported for backward compatibility, but they are wrapped inside a stateful transducer.
      The logic is: `:transduce`, if provided, takes precedence over `:transform` which, if provided is wrapped in a stateful transducer and takes precedence over the default `(map identity)`.
   * Although I don't think it's a big gain in terms of speed/memory efficiency because users probably won't do a lot of transformation (although we can't know) and the buffer size is not supposed to be *"too big"*™️. But I like how they compose.
   * I've isolated this change in its own commit so that you could reject it more easily should the change not suit you.
   * I've updated the documentation to reflect the change and explicitly declare the `:transform` configuration of the built-in publishers as deprecated in favor of `:transduce`.
   * All tests pass and the example project logs as expected.

I hope this is interesting to you and look forward to your feedback 🙂 