### PR TITLE
Correct capitalization for Elasticsearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 
 ## v0.2.0 - (2020-05-03)
-  - Added flag to support ElasticSearch v6.x correctly
+  - Added flag to support Elasticsearch v6.x correctly
   - Added `:mulog/trace-id` to base event with a flake (192 bit time-ordered unique id)
   - [**NEW**] Added Zipkin publisher
   - `μ/trace` function api change. (**BREAKING CHANGE**)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Available publishers:
   * [Simple console publisher (stdout)](#simple-console-publisher)
   * [Simple file publisher](#simple-file-publisher)
   * [Multi-publisher](#multi-publisher)
-  * [ElasticSearch](#elasticsearch-publisher)
+  * [Elasticsearch](#elasticsearch-publisher)
   * [Apache Kafka](#apache-kafka-publisher)
   * [Kinesis](#kinesis-publisher)
   * [Slack](#slack-publisher)
@@ -301,9 +301,9 @@ Here some best practices to follow while logging events:
       (catch Exception x
         (μ/log ::actionX :exception x :status :failed)))
     ```
-    It will be easier to search for all the error in ElasticSearch
+    It will be easier to search for all the error in Elasticsearch
     just by looking the presence of the `exception` key
-    (ElasticSearch query example `exception:*`)
+    (Elasticsearch query example `exception:*`)
 
 ## ***μ/trace***
 ![since v0.2.0](https://img.shields.io/badge/since-v0.2.0-brightgreen)
@@ -326,7 +326,7 @@ distributed tracers such as [Zipkin](https://zipkin.io/) and participate
 into distributed traces.
 
 ***μ/trace*** data points are not confined to distributed tracers,
-but the data can be used and interpreted in ElasticSearch, in real-time
+but the data can be used and interpreted in Elasticsearch, in real-time
 streaming system which use Apache Kafka etc.
 
 Assume that you have a complex operation which you want to track the
@@ -638,7 +638,7 @@ It will initialize all the configured publishers and return a function
 with no arguments which when called will stop all the publishers.
 
 
-### ElasticSearch publisher
+### Elasticsearch publisher
 ![since v0.1.0](https://img.shields.io/badge/since-v0.1.0-brightgreen)
 
 The events must be serializeable in JSON format ([Cheshire](https://github.com/dakrone/cheshire))
@@ -648,20 +648,20 @@ The available configuration options:
 ``` clojure
 {:type :elasticsearch
 
- ;; ElasticSearch endpoint (REQUIRED)
+ ;; Elasticsearch endpoint (REQUIRED)
  :url  "http://localhost:9200/"
 
 
- ;; The ElasticSearch version family.
+ ;; The Elasticsearch version family.
  ;; one of: `:auto` `:v6.x`  `:v7.x`
  :els-version   :auto
 
  ;; the maximum number of events which can be sent in a single
- ;; batch request to ElasticSearch
+ ;; batch request to Elasticsearch
  :max-items     5000
 
  ;; Interval in milliseconds between publish requests.
- ;; μ/log will try to send the records to ElasticSearch
+ ;; μ/log will try to send the records to Elasticsearch
  ;; with the interval specified.
  :publish-delay 5000
 

--- a/doc/els-name-mangling.md
+++ b/doc/els-name-mangling.md
@@ -1,16 +1,16 @@
-# Attribute name mangling on ElasticSearch
+# Attribute name mangling on Elasticsearch
 
-ElasticSearch can ingest documents without the necessity to define a
+Elasticsearch can ingest documents without the necessity to define a
 schema ahead of time.
 
 It is generally a good idea to define a [Mapping](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html)
-(schema in ElasticSearch terms) for your indices.
+(schema in Elasticsearch terms) for your indices.
 
 A Mapping allows for better optimisations of your indexes.
-ElasticSearch is capable of inferring the Mapping if one is not
+Elasticsearch is capable of inferring the Mapping if one is not
 provided explicitly.
 
-This capability makes very easy and quick to get started with ElasticSearch.
+This capability makes very easy and quick to get started with Elasticsearch.
 However, if the inferred type is incorrect it can lead to problems.
 
 For example, if you have a record for your Order as following:
@@ -27,7 +27,7 @@ For example, if you have a record for your Order as following:
 ```
 
 The `orderId` is a number automatically incremented by the DB.
-If you index this document in ElasticSearch with:
+If you index this document in Elasticsearch with:
 
 ```
 >>> PUT http://localhost:9200/orders/_doc/43253
@@ -196,7 +196,7 @@ configuration:
 ``` clojure
 {:type :elasticsearch
 
- ;; ElasticSearch endpoint (REQUIRED)
+ ;; Elasticsearch endpoint (REQUIRED)
  :url  "http://localhost:9200/"
 
  ;; Whether or not to change the attribute names

--- a/examples/roads-disruptions/README.md
+++ b/examples/roads-disruptions/README.md
@@ -32,7 +32,7 @@ This is necessary for the producer to connect to the broker.
 2. Update `src/com/brunobonacci/disruptions/main.clj/DEFAULT-CONFIG`'s
    Slack Publisher's `:webhook-url` to the Webhook you created in the
    previous step, uncomment the configuration section
-3. Start Kafka and ElasticSearch in background
+3. Start Kafka and Elasticsearch in background
 ``` shell
 docker-compose rm -f && docker-compose up
 ```
@@ -62,8 +62,8 @@ The logs will be sent to the following destinations:
   - Console standard output
   - Filesystem: `/tmp/mulog/events.log`
   - Kafka topic: `mulog`
-  - ElasticSearch index `mulog-YYYY.MM.DD`
-  - Zipkin + ElasticSearch (console http://localhost:9411/)
+  - Elasticsearch index `mulog-YYYY.MM.DD`
+  - Zipkin + Elasticsearch (console http://localhost:9411/)
 
 To see the events sent to Kafka run:
 

--- a/mulog-elasticsearch/README.md
+++ b/mulog-elasticsearch/README.md
@@ -1,8 +1,8 @@
-# μ/log -> ElasticSearch publisher
+# μ/log -> Elasticsearch publisher
 [![Clojars Project](https://img.shields.io/clojars/v/com.brunobonacci/mulog.svg)](https://clojars.org/com.brunobonacci/mulog)  [![cljdoc badge](https://cljdoc.org/badge/com.brunobonacci/mulog)](https://cljdoc.org/d/com.brunobonacci/mulog/CURRENT) ![CircleCi](https://img.shields.io/circleci/project/BrunoBonacci/mulog.svg) ![last-commit](https://img.shields.io/github/last-commit/BrunoBonacci/mulog.svg)
 
 
-This project contains the `publisher` for [ElasticSearch](https://www.elastic.co/products/elastic-stack)
+This project contains the `publisher` for [Elasticsearch](https://www.elastic.co/products/elastic-stack)
 
 
 ## Usage

--- a/mulog-elasticsearch/project.clj
+++ b/mulog-elasticsearch/project.clj
@@ -1,6 +1,6 @@
 (defn ver [] (-> "../ver/mulog.version" slurp .trim))
 (defproject com.brunobonacci/mulog-elasticsearch #=(ver)
-  :description "A publisher for μ/log to ElasticSearch."
+  :description "A publisher for μ/log to Elasticsearch."
 
   :url "https://github.com/BrunoBonacci/mulog"
 

--- a/mulog-elasticsearch/src/com/brunobonacci/mulog/publishers/elasticsearch.clj
+++ b/mulog-elasticsearch/src/com/brunobonacci/mulog/publishers/elasticsearch.clj
@@ -153,7 +153,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 
-(deftype ElasticSearchPublisher
+(deftype ElasticsearchPublisher
     [config buffer transform]
 
 
@@ -196,7 +196,7 @@
 (defn elasticsearch-publisher
   [{:keys [url max-items index-pattern] :as config}]
   {:pre [url]}
-  (ElasticSearchPublisher.
+  (ElasticsearchPublisher.
     (as-> config $
       (merge DEFAULT-CONFIG $)
       ;; autodetect version when set to `:auto`


### PR DESCRIPTION
Original comment in #27. Literally just did a `s/ElasticSearch/Elasticsearch/g` and ran a couple of tests. The test suite didn't have any assertions though.