### PR TITLE
Fix trace namespace to be bound at expansion time

### DIFF
--- a/mulog-core/src/com/brunobonacci/mulog/core.clj
+++ b/mulog-core/src/com/brunobonacci/mulog/core.clj
@@ -258,6 +258,6 @@
          :mulog/duration     ~duration
          :mulog/timestamp    ~ts
          :mulog/outcome      ~outcome
-         :mulog/namespace   (str *ns*))
+         :mulog/namespace   ~(str *ns*))
        ~pairs
        ~captures)))


### PR DESCRIPTION
Fixes #35.

I've never used the testing library used in `mulog` so help on writing a proper test would be appreciated.