### PR TITLE
Fix SlackPublisher trying to send empty messages

### DIFF
--- a/mulog-slack/src/com/brunobonacci/mulog/publishers/slack.clj
+++ b/mulog-slack/src/com/brunobonacci/mulog/publishers/slack.clj
@@ -53,6 +53,7 @@
 
 
 (deftype SlackPublisher [config buffer]
+
   com.brunobonacci.mulog.publisher.PPublisher
   (agent-buffer [_]
     buffer)
@@ -68,10 +69,12 @@
           transformed-events (transform (map second items))
           render-message (:render-message config)
           rendered-messages (map render-message transformed-events)]
+      ;; if the are rendered events, then send them
       (when (seq rendered-messages)
         (send-slack-message (:webhook-url config)
-                            (str/join "\n" rendered-messages)
-                            (:publish-delay config)))
+          (str/join "\n" rendered-messages)
+          (:publish-delay config)))
+      ;; discard the events we processed
       (if (seq items)
         (rb/dequeue buffer last-offset)
         buffer))))

--- a/mulog-slack/src/com/brunobonacci/mulog/publishers/slack.clj
+++ b/mulog-slack/src/com/brunobonacci/mulog/publishers/slack.clj
@@ -53,7 +53,6 @@
 
 
 (deftype SlackPublisher [config buffer]
-
   com.brunobonacci.mulog.publisher.PPublisher
   (agent-buffer [_]
     buffer)
@@ -69,13 +68,13 @@
           transformed-events (transform (map second items))
           render-message (:render-message config)
           rendered-messages (map render-message transformed-events)]
-      (if-not (seq items)
-        buffer
-        (do
-          (send-slack-message (:webhook-url config)
-            (str/join "\n" rendered-messages)
-            (:publish-delay config))
-          (rb/dequeue buffer last-offset))))))
+      (when (seq rendered-messages)
+        (send-slack-message (:webhook-url config)
+                            (str/join "\n" rendered-messages)
+                            (:publish-delay config)))
+      (if (seq items)
+        (rb/dequeue buffer last-offset)
+        buffer))))
 
 
 


### PR DESCRIPTION
Hi,

the Slack publisher isn't working for me when I configure it as described in the documentation. When the transform function filters all current items, it is still trying to send a slack message resulting in a "bad request" response from Slack, leading to an exception from clj-http. Because of the exception the buffer is not dequeued and sending the empty message is attempted in an endless loop.

This change separately checks if a Slack message needs to be sent and if the buffer needs to be dequeued.

Please let me know if this works for you.
