### PR TITLE
Prevent simple-file-publisher crashing

### DIFF
--- a/mulog-core/src/com/brunobonacci/mulog/publisher.clj
+++ b/mulog-core/src/com/brunobonacci/mulog/publisher.clj
@@ -104,8 +104,9 @@
   [{:keys [filename transform] :as config}]
   {:pre [filename]}
   (let [filename (io/file filename)]
-    ;; make parte dirs
-    (.mkdirs (.getParentFile filename))
+    ;; make parent dirs
+    (when-let [path (.getParentFile filename)]
+      (.mkdirs path))
     (SimpleFilePublisher.
       config
       (io/writer filename :append true)


### PR DESCRIPTION
When filename contains no path (i.e. just a file name in the current directory), .getParentFile returns nil, so .mkdirs crashes.