### PR TITLE
Add support for data-stream and extra http options on Elasticsearch

### DIFF
--- a/doc/publishers/elasticsearch-publisher.md
+++ b/doc/publishers/elasticsearch-publisher.md
@@ -36,8 +36,18 @@ The available configuration options:
  ;; with the interval specified.
  :publish-delay 5000
 
+ ;; Choose an indexing strategy:
+ ;; between `:index-pattern` or `:data-stream`, the default is `:index-pattern`
+
  ;; The index pattern to use for the events
- :index-pattern "'mulog-'yyyy.MM.dd"
+ ;; :index-pattern "'mulog-'yyyy.MM.dd"
+
+ ;; data streams are available since Elasticsearch 7.9
+ ;; :data-stream   "mulog-stream"
+
+ ;; extra http options to pass to the HTTP client
+ :http-opts {}
+
 
  ;; Whether or not to change the attribute names
  ;; to facilitate queries and avoid type clashing

--- a/mulog-core/dev/user.clj
+++ b/mulog-core/dev/user.clj
@@ -204,6 +204,10 @@
   (def x (u/start-publisher! {:type :elasticsearch
                               :url "http://localhost:9200/"}))
 
+  (def x (u/start-publisher! {:type :elasticsearch
+                              :url "http://localhost:9200/"
+                              :data-stream "mulog-stream"}))
+
   (x)
 
   )

--- a/mulog-elasticsearch/README.md
+++ b/mulog-elasticsearch/README.md
@@ -17,7 +17,9 @@ docker-compose rm -f && docker-compose up -d
 
 Then open: http://localhost:9000/ for Kibana, then add the index pattern `mulog-*`
 
-Follow the instructions at https://www.elastic.co/guide/en/elasticsearch/reference/current/set-up-a-data-stream.html to set up a data stream `tutorial-100`
+Follow the instructions at
+https://www.elastic.co/guide/en/elasticsearch/reference/current/set-up-a-data-stream.html
+to set up a data stream `mulog-stream`
 
 ## License
 

--- a/mulog-elasticsearch/README.md
+++ b/mulog-elasticsearch/README.md
@@ -17,6 +17,8 @@ docker-compose rm -f && docker-compose up -d
 
 Then open: http://localhost:9000/ for Kibana, then add the index pattern `mulog-*`
 
+Follow the instructions at https://www.elastic.co/guide/en/elasticsearch/reference/current/set-up-a-data-stream.html to set up a data stream `tutorial-100`
+
 ## License
 
 Copyright © 2019-2020 Bruno Bonacci - Distributed under the [Apache License v2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/mulog-elasticsearch/docker-compose.yml
+++ b/mulog-elasticsearch/docker-compose.yml
@@ -4,7 +4,8 @@ services:
   elasticsearch:
     #image: docker.elastic.co/elasticsearch/elasticsearch:6.7.0
     #image: docker.elastic.co/elasticsearch/elasticsearch:7.4.1
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.8.0
+    #image: docker.elastic.co/elasticsearch/elasticsearch:7.8.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.0
     ports:
       - "9200:9200"
       - "9300:9300"
@@ -13,6 +14,7 @@ services:
   kibana:
     #image: docker.elastic.co/kibana/kibana:6.7.0
     #image: docker.elastic.co/kibana/kibana:7.4.1
-    image: docker.elastic.co/kibana/kibana:7.8.0
+    #image: docker.elastic.co/kibana/kibana:7.8.0
+    image: docker.elastic.co/kibana/kibana:7.10.0
     ports:
       - "9000:5601"


### PR DESCRIPTION
add keys :data-stream :http-opts to publisher config

https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html#docs-bulk-api-desc

Data Streams support only the create action not the index action in the current publisher

Enable passthrough of extra clj-http options to clj-http. This enables keys like :headers and :insecure? to handle secured elasticsearch clusters