### PR TITLE
Restore http-opt in Elasticsearch Publisher post-records

### DIFF
--- a/mulog-elasticsearch/src/com/brunobonacci/mulog/publishers/elasticsearch.clj
+++ b/mulog-elasticsearch/src/com/brunobonacci/mulog/publishers/elasticsearch.clj
@@ -112,15 +112,15 @@
   [{:keys [url publish-delay http-opts] :as config} records]
   (-> (http/post
         (normalize-endpoint-url url)
-       (merge
-        http-opts
-        {:content-type "application/x-ndjson"
-         :accept :json
-         :socket-timeout publish-delay
-         :connection-timeout publish-delay
-         :body
-         (->> (prepare-records config records)
-              (apply str))}))
+        (merge
+          http-opts
+          {:content-type "application/x-ndjson"
+           :accept :json
+           :socket-timeout publish-delay
+           :connection-timeout publish-delay
+           :body
+           (->> (prepare-records config records)
+             (apply str))}))
     (update :body json/from-json)))
 
 

--- a/mulog-elasticsearch/src/com/brunobonacci/mulog/publishers/elasticsearch.clj
+++ b/mulog-elasticsearch/src/com/brunobonacci/mulog/publishers/elasticsearch.clj
@@ -109,16 +109,18 @@
 
 
 (defn- post-records
-  [{:keys [url publish-delay] :as config} records]
+  [{:keys [url publish-delay http-opts] :as config} records]
   (-> (http/post
         (normalize-endpoint-url url)
+       (merge
+        http-opts
         {:content-type "application/x-ndjson"
          :accept :json
          :socket-timeout publish-delay
          :connection-timeout publish-delay
          :body
          (->> (prepare-records config records)
-           (apply str))})
+              (apply str))}))
     (update :body json/from-json)))
 
 


### PR DESCRIPTION
Changes to Elasticsearch Publisher in #46  were overwritten in #47 