### PR TITLE
Added mulog-kafka integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ pom.xml.asc
 .hg/
 /mulog-core/temp/
 .calva
+.idea

--- a/mulog-kafka/.gitignore
+++ b/mulog-kafka/.gitignore
@@ -9,3 +9,5 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+mulog-kafka.iml
+.idea

--- a/mulog-kafka/project.clj
+++ b/mulog-kafka/project.clj
@@ -22,7 +22,17 @@
   :profiles {:dev {:dependencies [[midje "1.9.10"]
                                   [org.clojure/test.check "1.1.0"]
                                   [criterium "0.4.6"]
-                                  [org.slf4j/slf4j-log4j12 "2.0.0-alpha1"]]
+                                  [org.slf4j/slf4j-log4j12 "2.0.0-alpha1"]
+
+                                  ; slf4j -> mulog
+                                  [nonseldiha/slf4j-mulog "0.2.1"]
+
+                                  ; Clojure Kafka client
+                                  [com.appsflyer/ketu "0.6.0"]
+
+                                  ; Kafka docker-in-docker
+                                  [org.testcontainers/kafka "1.15.3"]
+                                  [clj-test-containers "0.4.0"]]
                    :resource-paths ["dev-resources"]
                    :plugins      [[lein-midje "3.2.2"]]}}
 

--- a/mulog-kafka/test/com/brunobonacci/mulog/publishers/container/kafka_setup.clj
+++ b/mulog-kafka/test/com/brunobonacci/mulog/publishers/container/kafka_setup.clj
@@ -1,0 +1,41 @@
+(ns com.brunobonacci.mulog.publishers.container.kafka-setup
+  (:require [com.brunobonacci.mulog :as logger]
+            [clj-test-containers.core :as tc]
+            [ketu.async.source :as source]
+            [clojure.core.async :as async])
+  (:import (org.testcontainers.containers KafkaContainer)
+           (org.testcontainers.utility DockerImageName)
+           (java.util UUID)))
+
+(def ^:private ^:const container-port 9093)
+
+(defn get-bootstrap-servers [kafka-container]
+  (.getBootstrapServers ^KafkaContainer (:container kafka-container)))
+
+(defn start-container! []
+  (logger/log ::creating-kafka-container)
+  (-> {:container     (KafkaContainer. (DockerImageName/parse "confluentinc/cp-kafka:6.1.0"))
+       :exposed-ports [container-port]}
+      tc/init
+      tc/start!))
+
+(defn stop-container! [kafka-container]
+  (tc/stop! kafka-container))
+
+(defn start-consuming [kafka-container topic]
+  (let [consumer-id (str "test-consumer-" (UUID/randomUUID))
+        channel     (async/chan 100)
+        source      (source/source
+                      channel
+                      {:name            consumer-id
+                       :topic           topic
+                       :group-id        consumer-id
+                       :brokers         (get-bootstrap-servers kafka-container)
+                       :value-type      :string
+                       :shape           :value
+                       :internal-config {"auto.offset.reset" "earliest"}})]
+    {:source  source
+     :channel channel}))
+
+(defn stop-consuming! [consumer]
+  (source/stop! (:source consumer)))

--- a/mulog-kafka/test/com/brunobonacci/mulog/publishers/kafka_test.clj
+++ b/mulog-kafka/test/com/brunobonacci/mulog/publishers/kafka_test.clj
@@ -1,0 +1,50 @@
+(ns com.brunobonacci.mulog.publishers.kafka-test
+  (:require [midje.sweet :refer :all]
+            [com.brunobonacci.mulog :as mu]
+            [com.brunobonacci.mulog.publishers.container.kafka-setup :as kafka-setup]
+            [clojure.core.async :as async]
+            [jsonista.core :as json]
+            [org.slf4j.impl.mulog]))
+
+(def ^:private ^:const TOPIC "mulog")
+
+(def ^:private json-mapper (json/object-mapper {:decode-key-fn true}))
+
+(defn- <!!? [chan milliseconds]
+  (let [timeout (async/timeout milliseconds)
+        [value _] (async/alts!! [chan timeout])]
+    value))
+
+(let [stop-console-pub (atom nil)
+      stop-kafka-pub   (atom nil)
+      kafka-container  (atom nil)
+      kafka-consumer   (atom nil)]
+  (with-state-changes [(before :facts
+                               (do
+                                 (reset! stop-console-pub (mu/start-publisher! {:type :console}))
+                                 (reset! kafka-container (kafka-setup/start-container!))
+                                 (reset! stop-kafka-pub (mu/start-publisher! {:type      :kafka
+                                                                              :kafka     {:bootstrap.servers (kafka-setup/get-bootstrap-servers @kafka-container)}
+                                                                              :topic     TOPIC
+                                                                              :transform (fn [events] (filter #(= (:mulog/event-name %) :ns/event) events))}))
+                                 (reset! kafka-consumer (kafka-setup/start-consuming @kafka-container TOPIC))))
+                       (after :facts (do
+                                       (kafka-setup/stop-consuming! @kafka-consumer)
+                                       (@stop-kafka-pub)
+                                       (kafka-setup/stop-container! @kafka-container)
+                                       (@stop-console-pub)))]
+
+    (fact "messages published to kafka can be retrieved"
+
+          (mu/log :ns/event :int 1 :string "data" :map {:a 1})
+
+          (some-> kafka-consumer
+                  deref
+                  :channel
+                  (<!!? 10000)
+                  (json/read-value json-mapper))
+
+          => (contains {:int              1
+                        :map              {:a 1}
+                        :mulog/event-name "ns/event"
+                        :string           "data"}))))

--- a/mulog-zipkin/.gitignore
+++ b/mulog-zipkin/.gitignore
@@ -9,3 +9,5 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+mulog-zipkin.iml
+.idea


### PR DESCRIPTION
In this PR, which resolves #51:

Added the following dependencies:
- [com.appsflyer/ketu](https://github.com/AppsFlyer/ketu) - KafkaConsumer abstraction using core.async channels
- [org.testcontainers/kafka](https://github.com/testcontainers/testcontainers-java) - To spin docker-in-docker kafka container
- [clj-test-containers](https://github.com/javahippie/clj-test-containers) - A thin clojure wrapper around org.testcontainers
- [nonseldiha/slf4j-mulog](https://gitlab.com/nonseldiha/slf4j-mulog) - To see the container logs

The integration tests do the following:
- Spins a Kafka container
- Subscribes mulog to it
- Starts a KafkaConsumer on the relevant topic
- Logs a message
- Waits and validates the log's fields in the Kafka message
- Closes all created resources