### PR TITLE
Update link to JSON encode custom Java classes document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - Added `:transform-samples` for samplers and fix (#72)
   - Added DEPRECATION WARNING: on `:filesystem-metrics` sampler config option (#74)
   - Added DEPRECATION WARNING: on `:mbean` sampler config option (#75)
+  - Fixed link to JSON encode custom Java classes (#80) (thanks @practicalli-john)
 
 
 ## v0.7.1 - (2021-03-23)
@@ -57,7 +58,7 @@
   - [**POTENTIALLY BREAKING**] Migrated to JSON encoding from Cheshire
     to Jasonista (thanks to @ozimos).  It is potentially breaking if
     you have custom JSON encoders setup for Cheshire you will need to
-    add them as described into [How to JSON encode custom Java classes](./doc/json-encode.md)
+    add them as described into [How to JSON encode custom Java classes](/doc/json-encode.md)
   - Fixed issue in SlackPublisher trying to send empty messages #41 (thanks @ak-coram)
   - Fixed issue in `simple-file-publisher` not handling files without parent dir #43 (thanks to @emlyn)
 

--- a/doc/publishers/cloudwatch-logs-publisher.md
+++ b/doc/publishers/cloudwatch-logs-publisher.md
@@ -12,7 +12,7 @@ In order to use the library add the dependency to your `project.clj`
 ```
 Current version: [![Clojars Project](https://img.shields.io/clojars/v/com.brunobonacci/mulog-cloudwatch.svg)](https://clojars.org/com.brunobonacci/mulog-cloudwatch)
 
-The events must be serializeable in JSON format (see [How to JSON encode custom Java classes](./doc/json-encode.md) for more info.)
+The events must be serializeable in JSON format (see [How to JSON encode custom Java classes](/doc/json-encode.md) for more info.)
 
 The available configuration options:
 

--- a/doc/publishers/elasticsearch-publisher.md
+++ b/doc/publishers/elasticsearch-publisher.md
@@ -12,7 +12,7 @@ In order to use the library add the dependency to your `project.clj`
 ```
 Current version: [![Clojars Project](https://img.shields.io/clojars/v/com.brunobonacci/mulog-elasticsearch.svg)](https://clojars.org/com.brunobonacci/mulog-elasticsearch)
 
-The events must be serializeable in JSON format (see [How to JSON encode custom Java classes](./doc/json-encode.md) for more info.)
+The events must be serializeable in JSON format (see [How to JSON encode custom Java classes](/doc/json-encode.md) for more info.)
 
 The available configuration options:
 

--- a/doc/publishers/kafka-publisher.md
+++ b/doc/publishers/kafka-publisher.md
@@ -13,7 +13,7 @@ In order to use the library add the dependency to your `project.clj`
 Current version: [![Clojars Project](https://img.shields.io/clojars/v/com.brunobonacci/mulog-kafka.svg)](https://clojars.org/com.brunobonacci/mulog-kafka)
 
 
-The events must be serializeable in JSON format (see [How to JSON encode custom Java classes](./doc/json-encode.md) for more info.)
+The events must be serializeable in JSON format (see [How to JSON encode custom Java classes](/doc/json-encode.md) for more info.)
 
 The available configuration options:
 

--- a/doc/publishers/kinesis-publisher.md
+++ b/doc/publishers/kinesis-publisher.md
@@ -12,7 +12,7 @@ In order to use the library add the dependency to your `project.clj`
 ```
 Current version: [![Clojars Project](https://img.shields.io/clojars/v/com.brunobonacci/mulog-kinesis.svg)](https://clojars.org/com.brunobonacci/mulog-kinesis)
 
-The events must be serializeable in JSON format (see [How to JSON encode custom Java classes](./doc/json-encode.md) for more info.)
+The events must be serializeable in JSON format (see [How to JSON encode custom Java classes](/doc/json-encode.md) for more info.)
 
 The available configuration options:
 

--- a/doc/publishers/slack-publisher.md
+++ b/doc/publishers/slack-publisher.md
@@ -12,7 +12,7 @@ In order to use the library add the dependency to your `project.clj`
 ```
 Current version: [![Clojars Project](https://img.shields.io/clojars/v/com.brunobonacci/mulog-slack.svg)](https://clojars.org/com.brunobonacci/mulog-slack)
 
-The events must be serializeable in JSON format (see [How to JSON encode custom Java classes](./doc/json-encode.md) for more info.)
+The events must be serializeable in JSON format (see [How to JSON encode custom Java classes](/doc/json-encode.md) for more info.)
 
 First get an [Incoming Webhook in Slack](https://api.slack.com/messaging/webhooks)
 following these steps:

--- a/doc/publishers/zipkin-publisher.md
+++ b/doc/publishers/zipkin-publisher.md
@@ -12,7 +12,7 @@ In order to use the library add the dependency to your `project.clj`
 ```
 Current version: [![Clojars Project](https://img.shields.io/clojars/v/com.brunobonacci/mulog-zipkin.svg)](https://clojars.org/com.brunobonacci/mulog-zipkin)
 
-The events must be serializeable in JSON format (see [How to JSON encode custom Java classes](./doc/json-encode.md) for more info.)
+The events must be serializeable in JSON format (see [How to JSON encode custom Java classes](/doc/json-encode.md) for more info.)
 
 The available configuration options:
 


### PR DESCRIPTION
The link on the respective publisher pages was using a respective path rather than an absolute path to the JSON encode page.

Update link on all affected publisher pages.

Links can be tested on practicalli-john fork of this repository, e.g.
https://github.com/practicalli-john/mulog/blob/link-to-json-encode-page/doc/publishers/cloudwatch-logs-publisher.md

Resolve #80