### PR TITLE
More flexible destinations for file writer

### DIFF
--- a/mulog-core/src/com/brunobonacci/mulog/publisher.clj
+++ b/mulog-core/src/com/brunobonacci/mulog/publisher.clj
@@ -100,18 +100,28 @@
 
 
 
+(defn- make-parent-dirs [f]
+  (condp instance? f
+    String
+    (make-parent-dirs (io/file f))
+
+    java.io.File
+    (when-let [path (.getParentFile f)]
+      (.mkdirs path))
+
+    nil))
+
+
+
 (defn simple-file-publisher
   [{:keys [filename transform] :as config}]
   {:pre [filename]}
-  (let [filename (io/file filename)]
-    ;; make parent dirs
-    (when-let [path (.getParentFile filename)]
-      (.mkdirs path))
-    (SimpleFilePublisher.
-      config
-      (io/writer filename :append true)
-      (rb/agent-buffer 10000)
-      (or transform identity))))
+  (make-parent-dirs filename)
+  (SimpleFilePublisher.
+    config
+    (io/writer filename :append true)
+    (rb/agent-buffer 10000)
+    (or transform identity)))
 
 
 


### PR DESCRIPTION
It would be useful to allow writing logs to other places than a local file.
This change allows it to accept anything that can be coerced into a writer (such as e.g. a Hadoop `FSDataOutputStream` for writing to a remote filesystem).
The current behaviour of creating the parent directories is maintained if the filename passed in is a string (or a File object).