### PR TITLE
Fix com.brunobonacci.mulog.utils/pprint-event-str

### DIFF
--- a/mulog-core/src/com/brunobonacci/mulog/utils.clj
+++ b/mulog-core/src/com/brunobonacci/mulog/utils.clj
@@ -14,11 +14,7 @@
     (catch Exception _
       0)))
 
-(defn ->namespace
-  "Return namespace for keyword or symbol, otherwise `nil`"
-  [x]
-  (when (or (keyword? x) (symbol? x))
-    (namespace x)))
+
 
 (defn java-version
   "It returns the current Java major version as a number"
@@ -84,13 +80,21 @@
 
 
 
+(defn- ->namespace
+  "Return namespace for keyword or symbol, otherwise `nil`"
+  [x]
+  (when (or (keyword? x) (symbol? x))
+    (namespace x)))
+
+
+
 (defn pprint-event-str
   "pretty print event to a string"
   [m]
   (let [ids [:mulog/trace-id   :mulog/root-trace :mulog/parent-trace]
         top [:mulog/event-name :mulog/timestamp ]
         mks (->> (keys m) (filter #(= "mulog" (->namespace %))) (remove (set (concat ids top))) (sort))
-        oks (->> (keys m) (remove #(= "mulog" (->namespace %))) (sort))
+        oks (->> (keys m) (remove #(= "mulog" (->namespace %))) (sort-by str))
         get-value (fn [k] (get m k))]
     (->> (map (juxt identity get-value) (concat top ids mks oks))
       (remove (let [ids (set ids)]

--- a/mulog-core/src/com/brunobonacci/mulog/utils.clj
+++ b/mulog-core/src/com/brunobonacci/mulog/utils.clj
@@ -14,7 +14,11 @@
     (catch Exception _
       0)))
 
-
+(defn ->namespace
+  "Return namespace for keyword or symbol, otherwise `nil`"
+  [x]
+  (when (or (keyword? x) (symbol? x))
+    (namespace x)))
 
 (defn java-version
   "It returns the current Java major version as a number"
@@ -85,8 +89,8 @@
   [m]
   (let [ids [:mulog/trace-id   :mulog/root-trace :mulog/parent-trace]
         top [:mulog/event-name :mulog/timestamp ]
-        mks (->> (keys m) (filter #(= "mulog" (namespace %))) (remove (set (concat ids top))) (sort))
-        oks (->> (keys m) (remove #(= "mulog" (namespace %))) (sort))
+        mks (->> (keys m) (filter #(= "mulog" (->namespace %))) (remove (set (concat ids top))) (sort))
+        oks (->> (keys m) (remove #(= "mulog" (->namespace %))) (sort))
         get-value (fn [k] (get m k))]
     (->> (map (juxt identity get-value) (concat top ids mks oks))
       (remove (let [ids (set ids)]

--- a/mulog-core/test/com/brunobonacci/utils_test.clj
+++ b/mulog-core/test/com/brunobonacci/utils_test.clj
@@ -23,3 +23,23 @@
   (ut/remove-nils '(1 nil 3)) => '(1 nil 3)
   (ut/remove-nils #{1 nil 3}) => #{1 nil 3}
   )
+
+
+
+(fact "about pprint-events: pretty prints all different type of events"
+
+  (ut/pprint-event-str
+    {:a              1
+     :foo/a          2
+     "string"        "bar"
+     nil             nil
+     :mulog/trace-id #mulog/flake "4k1urR3C1p6SzVlF18urraWHAUPiK4-A"
+     :mulog/event-name 1234
+     :mulog/timestamp 1234567890
+     true            false
+     1.2             2.1
+     [1 2 3]         [3 2 1]
+     {:b 1}          {:c 2}})
+   => "{:mulog/event-name 1234,\n :mulog/timestamp 1234567890,\n :mulog/trace-id #mulog/flake \"4k1urR3C1p6SzVlF18urraWHAUPiK4-A\",\n nil nil,\n 1.2 2.1,\n :a 1,\n :foo/a 2,\n [1 2 3] [3 2 1],\n \"string\" \"bar\",\n true false,\n {:b 1} {:c 2}}\n"
+
+  )


### PR DESCRIPTION
If a key was not a keyword or symbol, `pprint-event-str` cause log to silently fail.

For example:

```clojure
(mu/log ::test "k" 123)
```

Nothing is logged here. `pprint-event-str` calls `clojure.core/namespace` on all the keys, which causes a `ClassCastException`. This exception is, however, swallowed, and the `log` call fails silently.

The solution is simply to check whether a key is a keyword or symbol prior to calling `namespace`.