### PR TITLE
Use pr-str instead of str for zipkin tag values

### DIFF
--- a/mulog-zipkin/src/com/brunobonacci/mulog/publishers/zipkin.clj
+++ b/mulog-zipkin/src/com/brunobonacci/mulog/publishers/zipkin.clj
@@ -72,7 +72,7 @@
             ;; tags values must be a string (can't be maps)
             ;; although numbers are accepted in zipkin, they're not
             ;; accepted in Jaeger (and maybe other).
-            :tags      (ut/map-values str (ut/remove-nils (flag-if-error e)))}))))
+            :tags      (ut/map-values pr-str (ut/remove-nils (flag-if-error e)))}))))
 
 
 

--- a/mulog-zipkin/src/com/brunobonacci/mulog/publishers/zipkin.clj
+++ b/mulog-zipkin/src/com/brunobonacci/mulog/publishers/zipkin.clj
@@ -72,7 +72,7 @@
             ;; tags values must be a string (can't be maps)
             ;; although numbers are accepted in zipkin, they're not
             ;; accepted in Jaeger (and maybe other).
-            :tags      (ut/map-values pr-str (ut/remove-nils (flag-if-error e)))}))))
+            :tags      (ut/map-values ut/edn-str (ut/remove-nils (flag-if-error e)))}))))
 
 
 


### PR DESCRIPTION
With `str`, the tag value could be something useless like `"clojure.lang.LazySeq@1b554e1"`