### PR TITLE
Docs for :capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ We can also trace the output of the function call using `µ/trace` using the `:c
 
 ```
 (μ/trace ::availability
-  {:pairs [:product-id product-id] 
+  {:pairs [:product/id product-id] 
    :capture 
     (fn [{:keys [inventory ordered shipped] :as a}]
      {:availability a})}
@@ -488,8 +488,8 @@ We can also trace the output of the function call using `µ/trace` using the `:c
 ;;  :mulog/outcome :ok,
 ;;  :app-name "mulog-demo",
 ;;  :env "local",
-;;  :product_id "2345-23-545",
-;;  :availability {:inventory 10,
+;;  :product/id "2345-23-545",
+;;  :product/availability {:inventory 10,
 ;;                 :ordered 5,
 ;;                 :shipped 2},
 ;;  :version "0.1.0"}

--- a/README.md
+++ b/README.md
@@ -469,6 +469,32 @@ One important difference between `with-context` and the `μ/trace`
 all nested calls* while the `μ/trace` pairs will be only added to that
 specific trace event and not the nested ones.
 
+We can also trace the output of the function call using `µ/trace` using the `:capture` parameter:
+
+```
+(μ/trace ::availability
+  {:pairs [:product-id product-id] 
+   :capture 
+    (fn [{:keys [inventory ordered shipped] :as a}]
+     {:availability a})}
+  (product-availability product-id))
+
+;; {:mulog/event-name :your-ns/availability,
+;;  :mulog/timestamp 1587504242983,
+;;  :mulog/trace-id #mulog/flake "4VTF9QBbnef57vxVy-b4uKzh7dG7r7y4",
+;;  :mulog/root-trace #mulog/flake "4VTF9QBbnef57vxVy-b4uKzh7dG7r7y4",
+;;  :mulog/duration 254402837,
+;;  :mulog/namespace "your-ns",
+;;  :mulog/outcome :ok,
+;;  :app-name "mulog-demo",
+;;  :env "local",
+;;  :product_id "2345-23-545",
+;;  :availability {:inventory 10,
+;;                 :ordered 5,
+;;                 :shipped 2},
+;;  :version "0.1.0"}
+```
+
 If we had the following set of nested calls:
 
 ``` clojure


### PR DESCRIPTION
I find it useful to capture the output of traced functions in the trace logs. User cddr from Slack suggested that :capture would do it, so I added documentation for how to use it so other users find it more easily.